### PR TITLE
add MANIFEST.in and include_package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,5 @@ This project is hosted at https://github.com/EpistasisLab/scikit-rebate
         'Topic :: Utilities'
     ],
     keywords=['data mining', 'feature selection', 'feature importance', 'machine learning', 'data analysis', 'data engineering', 'data science'],
+    include_package_data=True,
 )


### PR DESCRIPTION
Hi folks!

This little PR just ensures that the LICENSE file gets included along with the distribution. If you'd prefer just the `package_data` line rather than a MANIFEST.in, I can re-submit, but this seems to be the more conventional approach.

Background: working on packaging this over on conda-forge:
https://github.com/conda-forge/staged-recipes/pull/4708

Of course let me know if anyone from the team would like to co-maintain: otherwise I'll be bumping versions on a best-effort basis, and always welcome a heads-up issue!

I looked into including the tests, and saw that they bring along some rather big-ish fixture data, so i didn't just drop those right in, but we'll run them, too, if you include them in your distribution!